### PR TITLE
Show users in orders overview

### DIFF
--- a/lib/money_pit/accounts/user.ex
+++ b/lib/money_pit/accounts/user.ex
@@ -243,8 +243,12 @@ defmodule MoneyPit.Accounts.User do
       authorize_if actor_attribute_equals(:role, :admin)
     end
 
-    policy always() do
-      forbid_if always()
+    policy action_type(:read) do
+      # Admins can read all users
+      authorize_if actor_attribute_equals(:role, :admin)
+
+      # Users can read their own user record
+      authorize_if expr(id == ^actor(:id))
     end
   end
 

--- a/lib/money_pit_web/live/orders_live.ex
+++ b/lib/money_pit_web/live/orders_live.ex
@@ -55,7 +55,7 @@ defmodule MoneyPitWeb.OrdersLive do
         },
         socket
       ) do
-    order = Ash.load!(notification.data, :product, actor: socket.assigns.current_user)
+    order = Ash.load!(notification.data, [:product, :user], actor: socket.assigns.current_user)
 
     {:noreply, stream_insert(socket, :orders, order, at: 0)}
   end
@@ -66,7 +66,7 @@ defmodule MoneyPitWeb.OrdersLive do
         socket
       ) do
     # Load the product relationship on the order from the notification
-    order = Ash.load!(notification.data, :product, actor: socket.assigns.current_user)
+    order = Ash.load!(notification.data, [:product, :user], actor: socket.assigns.current_user)
 
     {:noreply, stream_insert(socket, :orders, order)}
   end
@@ -75,7 +75,7 @@ defmodule MoneyPitWeb.OrdersLive do
     orders =
       MoneyPit.Commerce.list_orders!(
         actor: socket.assigns.current_user,
-        load: [:product]
+        load: [:product, :user]
       )
       |> Enum.sort_by(& &1.inserted_at, {:desc, DateTime})
 
@@ -143,6 +143,9 @@ defmodule MoneyPitWeb.OrdersLive do
             </:col>
             <:col :let={{_id, order}} label="Product">
               {order.product.name}
+            </:col>
+            <:col :let={{_id, order}} label="User">
+              {if order.user, do: to_string(order.user.email), else: "No user"}
             </:col>
             <:col :let={{_id, order}} label="Amount">
               <span class="font-semibold text-success">


### PR DESCRIPTION
Show the user's e-mail in the order overview... However, I'm not 100% about the Ash policy evaluation. I removed the final 

```elixir
policy always() do
  forbid_if always()
end
```

because when I kept it in, admins can't read all users, and users can't read their own entry. 

Thanks @ChristianAlexander for the great video and repo. I'm currently learning Ash, so take my hack with a grain of salt. No need to accept this PR, but I would love to understand whether the change to the `User` policy is OK.